### PR TITLE
Fix modifier key strings

### DIFF
--- a/src/inject.js
+++ b/src/inject.js
@@ -243,7 +243,7 @@ var domUtils = {
           '<button aria-label="Copy file contents to clipboard" class="js-file-clipboard btn btn-sm BtnGroup-item file-clipboard-button tooltipped tooltipped-s" data-copied-hint="Copied!" type="button" click="selectText()" data-clipboard-target="tbody">' +
             'Copy File' +
           '</button>' +
-          '<a href="' + data.download_url + '" download="' + data.name + '" aria-label="(Alt/Cmd/Ctr + Click) to download File" class="js-file-download btn btn-sm BtnGroup-item file-download-button tooltipped tooltipped-s">' +
+          '<a href="' + data.download_url + '" download="' + data.name + '" aria-label="(Alt/Option/Ctrl + Click) to download File" class="js-file-download btn btn-sm BtnGroup-item file-download-button tooltipped tooltipped-s">' +
             '<span style="margin-right: 5px;">' + formattedFileSize + '</span>' +
               '<svg class="octicon octicon-cloud-download" aria-hidden="true" height="16" version="1.1" viewBox="0 0 16 16" width="16">' +
               '<path d="M9 12h2l-3 3-3-3h2V7h2v5zm3-8c0-.44-.91-3-4.5-3C5.08 1 3 2.92 3 5 1.02 5 0 6.52 0 8c0 1.53 1 3 3 3h3V9.7H3C1.38 9.7 1.3 8.28 1.3 8c0-.17.05-1.7 1.7-1.7h1.3V5c0-1.39 1.56-2.7 3.2-2.7 2.55 0 3.13 1.55 3.2 1.8v1.2H12c.81 0 2.7.22 2.7 2.2 0 2.09-2.25 2.2-2.7 2.2h-2V11h2c2.08 0 4-1.16 4-3.5C16 5.06 14.08 4 12 4z"></path>' +
@@ -291,7 +291,7 @@ var domUtils = {
 
             var html = '<td class="download" style="width: 20px;padding-right: 10px;color: #888;text-align: right;white-space: nowrap;">' +
               '<span style="margin-right: 5px;">' + formattedFileSize + '</span>' +
-              '<a href="' + data[i].download_url + '" title="(Alt/Cmd/Ctr + Click) to download File" aria-label="(Alt/Cmd/Ctr + Click) to download File" class="tooltipped tooltipped-nw" download="' + data[i].name + '">' +
+              '<a href="' + data[i].download_url + '" title="(Alt/Option/Ctrl + Click) to download File" aria-label="(Alt/Option/Ctrl + Click) to download File" class="tooltipped tooltipped-nw" download="' + data[i].name + '">' +
                 '<svg class="octicon octicon-cloud-download" aria-hidden="true" height="16" version="1.1" viewBox="0 0 16 16" width="16">' +
                 '<path d="M9 12h2l-3 3-3-3h2V7h2v5zm3-8c0-.44-.91-3-4.5-3C5.08 1 3 2.92 3 5 1.02 5 0 6.52 0 8c0 1.53 1 3 3 3h3V9.7H3C1.38 9.7 1.3 8.28 1.3 8c0-.17.05-1.7 1.7-1.7h1.3V5c0-1.39 1.56-2.7 3.2-2.7 2.55 0 3.13 1.55 3.2 1.8v1.2H12c.81 0 2.7.22 2.7 2.2 0 2.09-2.25 2.2-2.7 2.2h-2V11h2c2.08 0 4-1.16 4-3.5C16 5.06 14.08 4 12 4z"></path>' +
                 '</svg>' +


### PR DESCRIPTION
Hello,

To download file on macOS, we have to `Option` + click to download file. `Cmd` + click will just open a link in new background tab.

See: Chrome keyboard shortcuts - Google Chrome Help - https://support.google.com/chrome/answer/157179?hl=en

Also, I changed `ctr` to `ctrl` because a normal keyboard has `Ctrl` label for the control key.