### PR TITLE
Adjust the alignment of share buttons in the option page

### DIFF
--- a/options.html
+++ b/options.html
@@ -120,7 +120,7 @@
 	<div class="background--grey  padding--10  text--center">
 		<div style="padding: 15px 10px;">
 			<!-- Place this tag where you want the button to render. -->
-			<iframe src="https://ghbtns.com/github-btn.html?user=softvar&repo=enhanced-github&type=star&count=true&size=large" frameborder="0" scrolling="0" width="160px" height="30px"></iframe>
+			<iframe src="https://ghbtns.com/github-btn.html?user=softvar&repo=enhanced-github&type=star&count=true&size=large" frameborder="0" scrolling="0" width="160px" height="38px"></iframe>
 
 		  <iframe
 				src="https://platform.twitter.com/widgets/tweet_button.html?size=l&url=http://github.com/softvar/enhanced-github&via=s0ftvar&text=Display size of each file, download link and option to copy file contents&hashtags=extension,github"


### PR DESCRIPTION
Two share buttons in the option modal dialog were not aligned properly. 
This PR fix the problem by fixing the height of iframe of GitHub star button.

**Before:**
<img width="622" alt="2018-10-14 21 53 21" src="https://user-images.githubusercontent.com/1425259/46916966-a9aa0400-cffc-11e8-8419-2e3bdb698c0e.png">

**After:**
<img width="608" alt="2018-10-14 21 55 37" src="https://user-images.githubusercontent.com/1425259/46916969-add62180-cffc-11e8-863f-7624e37fbe4d.png">
