### PR TITLE
Use GitHub grey color for the size column

### DIFF
--- a/src/inject.js
+++ b/src/inject.js
@@ -289,7 +289,7 @@ var domUtils = {
           if (data[i].type === 'file') {
             var formattedFileSize = utils.getFileSizeAndUnit(data[i]);
 
-            var html = '<td class="download" style="width: 20px;padding-right: 10px;color: #888;text-align: right;white-space: nowrap;">' +
+            var html = '<td class="download" style="width: 20px;padding-right: 10px;color: #6a737d;text-align: right;white-space: nowrap;">' +
               '<span style="margin-right: 5px;">' + formattedFileSize + '</span>' +
               '<a href="' + data[i].download_url + '" title="(Alt/Option/Ctrl + Click) to download File" aria-label="(Alt/Option/Ctrl + Click) to download File" class="tooltipped tooltipped-nw" download="' + data[i].name + '">' +
                 '<svg class="octicon octicon-cloud-download" aria-hidden="true" height="16" version="1.1" viewBox="0 0 16 16" width="16">' +


### PR DESCRIPTION
The current text color does not fit well with a color of age (time) column used by GitHub. So I changed the text color of the download column with the GitHub grey color.

<img width="214" alt="Screen Shot 2019-05-27 at 4 13 37 PM" src="https://user-images.githubusercontent.com/6178510/58402121-89661b80-809a-11e9-955b-c16fc306df1d.png">

Here is a screenshot to compare each version. The above is the updated version and below is the current version.